### PR TITLE
feat(player): add similar accounts mode anchored on Steam ID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+ref: @AGENTS.md

--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -206,6 +206,20 @@
 				"error": "Failed to generate image",
 				"retry": "Retry",
 				"help": "Download the image or copy it to your clipboard to share"
+			},
+			"neighbors": {
+				"button": "Similar accounts",
+				"buttonTitle": "Show accounts registered next to this player",
+				"label": "Similar accounts",
+				"bannerAnchored": "Similar accounts to {username}",
+				"bannerSortOnly": "Ordered by similar accounts",
+				"range": "ranks {start}–{end}",
+				"hint": "Ordering comes from the player's Steam ID, which the API never returns.",
+				"exit": "Exit",
+				"notFound": "That player was not found in this database, showing the start of the list instead.",
+				"dismiss": "Dismiss",
+				"previousWindow": "Previous {count}",
+				"nextWindow": "Next {count}"
 			}
 		},
 		"footer": {
@@ -261,7 +275,8 @@
 			"togglePlayerDetails": "Toggle player details",
 			"clickToSort": "Click to sort",
 			"previewMap": "Preview map",
-			"sharePlayer": "Share player stats as image"
+			"sharePlayer": "Share player stats as image",
+			"findNeighbors": "Show similar accounts"
 		}
 	}
 }

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -206,6 +206,20 @@
 				"error": "生成图片失败",
 				"retry": "重试",
 				"help": "下载图片或复制到剪贴板进行分享"
+			},
+			"neighbors": {
+				"button": "相近账号",
+				"buttonTitle": "查看与该玩家注册相近的账号",
+				"label": "相近账号",
+				"bannerAnchored": "{username} 的相近账号",
+				"bannerSortOnly": "已按相近账号排序",
+				"range": "第 {start}–{end} 名",
+				"hint": "排序依据玩家 Steam ID，接口不会返回该值。",
+				"exit": "退出",
+				"notFound": "本数据库中未找到该玩家，已显示列表开头。",
+				"dismiss": "关闭",
+				"previousWindow": "上 {count} 名",
+				"nextWindow": "下 {count} 名"
 			}
 		},
 		"footer": {
@@ -277,7 +291,8 @@
 			"togglePlayerDetails": "切换玩家详情",
 			"clickToSort": "点击排序",
 			"previewMap": "预览地图",
-			"sharePlayer": "分享玩家统计图片"
+			"sharePlayer": "分享玩家统计图片",
+			"findNeighbors": "查看相近账号"
 		}
 	}
 }

--- a/src/lib/components/PlayerTable.svelte
+++ b/src/lib/components/PlayerTable.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import TranslatedText from '$lib/components/TranslatedText.svelte';
 	import { m } from '$lib/paraglide/messages.js';
-	import { ArrowDown, Info, Share } from '@lucide/svelte';
+	import { ArrowDown, Info, Share, Users } from '@lucide/svelte';
 	import type { IPlayerItem, IPlayerColumn } from '$lib/models/player.model';
 	import { escapeHtml } from '$lib/utils/highlight';
 	import './table.css';
@@ -15,6 +15,7 @@
 		sortColumn: string | null;
 		onSort?: (column: string) => void;
 		onShare?: (player: IPlayerItem) => void;
+		onFindNeighbors?: (player: IPlayerItem) => void;
 	}
 
 	let {
@@ -25,7 +26,8 @@
 		highlightedUsername,
 		sortColumn = null,
 		onSort = () => {},
-		onShare
+		onShare,
+		onFindNeighbors
 	}: Props = $props();
 
 	// Helper function to get the display value for a column
@@ -129,7 +131,7 @@
 											: 'align-middle'} {column.key === 'action' ? 'action-cell' : ''}"
 								>
 									{#if column.key === 'action'}
-										<div class="flex items-center justify-center text-center">
+										<div class="flex items-center justify-center gap-1 text-center">
 											<button
 												type="button"
 												class="btn btn-ghost btn-xs btn-circle"
@@ -138,6 +140,18 @@
 											>
 												<Share class="w-4 h-4" />
 											</button>
+											{#if onFindNeighbors}
+												<button
+													type="button"
+													class="btn btn-ghost btn-xs btn-circle"
+													data-testid="find-neighbors"
+													onclick={() => onFindNeighbors(item)}
+													title={m['app.player.neighbors.buttonTitle']()}
+													aria-label={m['app.ariaLabel.findNeighbors']()}
+												>
+													<Users class="w-4 h-4" />
+												</button>
+											{/if}
 										</div>
 									{:else}
 										{@html getDisplayValue(item, column, searchQuery)}
@@ -173,13 +187,13 @@
 	}
 
 	:global(.player-table-wrapper .action-cell) {
-		min-width: 5rem;
-		width: 5rem;
+		min-width: 6.5rem;
+		width: 6.5rem;
 	}
 
 	:global(.player-table-wrapper .action-header) {
-		min-width: 5rem;
-		width: 5rem;
+		min-width: 6.5rem;
+		width: 6.5rem;
 	}
 
 	/* Mobile responsive adjustments for PlayerTable */

--- a/src/lib/components/PlayerTable.svelte
+++ b/src/lib/components/PlayerTable.svelte
@@ -120,7 +120,10 @@
 			<tbody>
 				{#each data as item (item.id)}
 					{@const isHighlighted = highlightedUsername && item.username.toLowerCase() === highlightedUsername.toLowerCase()}
-					<tr class="min-h-12 border-b border-mil {isHighlighted ? 'highlighted-row bg-primary/20 font-semibold' : 'hover hover:bg-base-300'}">
+					<tr
+						id={`player-row-${item.id}`}
+						class="min-h-12 border-b border-mil {isHighlighted ? 'highlighted-row bg-primary/20 font-semibold' : 'hover hover:bg-base-300'}"
+					>
 						{#each playerColumns as column (column.key)}
 							{#if visibleColumns[column.key]}
 								<td

--- a/src/lib/components/PlayerView.svelte
+++ b/src/lib/components/PlayerView.svelte
@@ -132,6 +132,53 @@
 		}
 	});
 
+	// The anchored player usually sits below the fold (row 11 of the window on desktop, an even
+	// taller stack of cards on mobile). Bring it into view once per loaded window - keyed on the
+	// window's first rank as well, because the anchor is already on screen in the previous
+	// window when neighbor mode is entered.
+	// Plain let: writing it must not re-trigger the effect.
+	let lastScrolledKey: string | null = null;
+
+	$effect(() => {
+		if (!sidAnchor) {
+			lastScrolledKey = null;
+			return;
+		}
+		// Rows and cards are unmounted while loading, so wait for the new window to render
+		if (loading) return;
+
+		const windowTop = paginatedPlayers[0] ?? mobilePaginatedPlayers[0];
+		if (!windowTop) return;
+
+		const key = `${sidAnchor}@${windowTop.rowNumber}`;
+		if (lastScrolledKey === key) return;
+
+		const anchorLower = sidAnchor.toLowerCase();
+		const matchesAnchor = (player: IPlayerItem) => player.username.toLowerCase() === anchorLower;
+		const desktopTarget = paginatedPlayers.find(matchesAnchor);
+		const mobileTarget = mobilePaginatedPlayers.find(matchesAnchor);
+
+		// Both trees are mounted; the one hidden by the breakpoint has no box, so scrolling it
+		// is a no-op and this stays viewport-agnostic.
+		const targets = [
+			desktopTarget && document.getElementById(`player-row-${desktopTarget.id}`),
+			mobileTarget && document.getElementById(`player-mobile-card-${mobileTarget.id}`)
+		].filter((element): element is HTMLElement => Boolean(element));
+
+		// Not rendered yet: leave the key unset so a later update retries
+		if (targets.length === 0) return;
+
+		lastScrolledKey = key;
+		requestAnimationFrame(() => {
+			for (const element of targets) {
+				// Absent where scrollIntoView is unimplemented (jsdom)
+				if (typeof element.scrollIntoView === 'function') {
+					element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+				}
+			}
+		});
+	});
+
 	const tableOnlyContainerClasses = 'md:flex-1 md:min-h-0 md:overflow-hidden';
 	const tableOnlyScrollClasses = 'md:flex-1 md:min-h-0 md:overflow-auto';
 	const fullPageScrollClasses = 'md:overflow-x-auto';
@@ -291,7 +338,15 @@
 				{/if}
 
 				{#each mobilePaginatedPlayers as item (item.id)}
-					<div class="collapse collapse-arrow bg-base-100 border-base-300 mb-3 border">
+					{@const isHighlighted =
+						highlightedUsername &&
+						item.username.toLowerCase() === highlightedUsername.toLowerCase()}
+					<div
+						id={`player-mobile-card-${item.id}`}
+						class="collapse collapse-arrow mb-3 border {isHighlighted
+							? 'highlighted-card border-primary bg-primary/20 font-semibold'
+							: 'bg-base-100 border-base-300'}"
+					>
 						<input
 							id={`player-mobile-collapse-${item.id}`}
 							type="checkbox"

--- a/src/lib/components/PlayerView.svelte
+++ b/src/lib/components/PlayerView.svelte
@@ -7,7 +7,7 @@
 	import PageSizeSelector from '$lib/components/PageSizeSelector.svelte';
 	import Toast from '$lib/components/Toast.svelte';
 	import { m } from '$lib/paraglide/messages.js';
-	import { ArrowDown, CircleX, Info, Share } from '@lucide/svelte';
+	import { ArrowDown, CircleX, Info, Share, TriangleAlert, Users, X } from '@lucide/svelte';
 	import type { IPlayerItem, IPlayerColumn } from '$lib/models/player.model';
 	import { escapeHtml } from '$lib/utils/highlight';
 
@@ -29,12 +29,22 @@
 		layoutMode: 'fullPage' | 'tableOnly';
 		hasNext: boolean;
 		hasPrevious: boolean;
+		/** Username the SID window is anchored on, null when not in neighbor mode */
+		sidAnchor?: string | null;
+		/** SID ordering is active (with or without an anchor) */
+		sidSortActive?: boolean;
+		/** Anchor was not found in this database and neighbor mode was left */
+		sidAnchorMissing?: boolean;
 		onSort: (column: string) => void;
 		onPageChange: (page: number) => void;
 		onPageSizeChange: (size: number) => void;
 		onLoadMore: () => void;
 		onToggleMobileCard: (playerId: string) => void;
 		onShare?: (player: IPlayerItem) => void;
+		onFindNeighbors?: (player: IPlayerItem) => void;
+		onExitSidMode?: () => void;
+		onShiftSidWindow?: (direction: 1 | -1) => void;
+		onDismissSidAnchorMissing?: () => void;
 	}
 
 	let {
@@ -55,13 +65,25 @@
 		layoutMode,
 		hasNext,
 		hasPrevious,
+		sidAnchor = null,
+		sidSortActive = false,
+		sidAnchorMissing = false,
 		onSort,
 		onPageChange,
 		onPageSizeChange,
 		onLoadMore,
 		onToggleMobileCard,
-		onShare
+		onShare,
+		onFindNeighbors,
+		onExitSidMode,
+		onShiftSidWindow,
+		onDismissSidAnchorMissing
 	}: Props = $props();
+
+	// Absolute rank range of the loaded window, read from the upstream row numbers
+	const windowRangeStart = $derived(paginatedPlayers[0]?.rowNumber ?? 0);
+	const windowRangeEnd = $derived(paginatedPlayers[paginatedPlayers.length - 1]?.rowNumber ?? 0);
+	const canShiftBackward = $derived(windowRangeStart > 1);
 
 	// Helper function to get the display value for a column
 	function getDisplayValue(
@@ -123,6 +145,54 @@
 		<span>{error}</span>
 	</div>
 {:else}
+	<!-- Anchor player missing in this database: upstream silently answered with the first page -->
+	{#if sidAnchorMissing}
+		<div class="alert alert-warning mb-3" data-testid="sid-anchor-missing">
+			<TriangleAlert class="h-5 w-5 shrink-0 stroke-current" />
+			<span><TranslatedText key="app.player.neighbors.notFound" /></span>
+			<button
+				type="button"
+				class="btn btn-ghost btn-xs btn-circle"
+				onclick={() => onDismissSidAnchorMissing?.()}
+				aria-label={m['app.player.neighbors.dismiss']()}
+			>
+				<X class="h-4 w-4" />
+			</button>
+		</div>
+	{/if}
+
+	<!-- SID ordering has no table column, so its state is surfaced here -->
+	{#if sidSortActive}
+		<div
+			class="mb-3 flex flex-wrap items-center justify-between gap-2 rounded border border-mil bg-mil-secondary px-3 py-2 text-sm"
+			data-testid="sid-mode-banner"
+		>
+			<div class="flex flex-wrap items-center gap-2">
+				<Users class="h-4 w-4 shrink-0" />
+				{#if sidAnchor}
+					<span class="font-medium">
+						{m['app.player.neighbors.bannerAnchored']({ username: sidAnchor })}
+					</span>
+				{:else}
+					<span class="font-medium"><TranslatedText key="app.player.neighbors.bannerSortOnly" /></span>
+				{/if}
+				{#if windowRangeStart > 0}
+					<span class="opacity-70">
+						{m['app.player.neighbors.range']({ start: windowRangeStart, end: windowRangeEnd })}
+					</span>
+				{/if}
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="hidden opacity-60 lg:inline"
+					><TranslatedText key="app.player.neighbors.hint" /></span
+				>
+				<button type="button" class="btn btn-xs" onclick={() => onExitSidMode?.()}>
+					<TranslatedText key="app.player.neighbors.exit" />
+				</button>
+			</div>
+		</div>
+	{/if}
+
 	<!-- Desktop scrollable table container -->
 	<div class={`hidden md:flex md:flex-col ${layoutMode === 'tableOnly' ? tableOnlyContainerClasses : ''}`}>
 		<!-- Desktop table with scroll -->
@@ -136,19 +206,49 @@
 				{sortColumn}
 				onSort={onSort}
 				onShare={onShare}
+				onFindNeighbors={onFindNeighbors}
 			/>
 		</div>
 
-		<!-- Desktop pagination - fixed at bottom, hidden when no pagination needed -->
-		<div class="flex items-center justify-between border-t border-mil bg-mil-secondary px-3 py-2" class:hidden={!hasNext && !hasPrevious}>
-			<PaginationPrevNext
-				{currentPage}
-				{hasNext}
-				{hasPrevious}
-				onPageChange={onPageChange}
-			/>
-			<PageSizeSelector currentSize={pageSize} onSizeChange={onPageSizeChange} />
-		</div>
+		{#if sidAnchor}
+			<!-- Anchored requests cannot be paginated upstream: browse by absolute row offset -->
+			<div
+				class="flex items-center justify-between border-t border-mil bg-mil-secondary px-3 py-2"
+				data-testid="sid-window-nav"
+			>
+				<div class="join">
+					<button
+						type="button"
+						class="join-item btn btn-sm"
+						disabled={!canShiftBackward}
+						onclick={() => onShiftSidWindow?.(-1)}
+					>
+						‹ {m['app.player.neighbors.previousWindow']({ count: pageSize })}
+					</button>
+					<button
+						type="button"
+						class="join-item btn btn-sm"
+						data-testid="sid-window-next"
+						disabled={!hasNext}
+						onclick={() => onShiftSidWindow?.(1)}
+					>
+						{m['app.player.neighbors.nextWindow']({ count: pageSize })} ›
+					</button>
+				</div>
+				<PageSizeSelector currentSize={pageSize} onSizeChange={onPageSizeChange} />
+			</div>
+		{:else}
+			<!-- Desktop pagination - fixed at bottom, hidden when no pagination needed -->
+			<div class="flex items-center justify-between border-t border-mil bg-mil-secondary px-3 py-2" class:hidden={!hasNext && !hasPrevious}>
+				<PaginationPrevNext
+					{currentPage}
+					{hasNext}
+					{hasPrevious}
+					onPageChange={onPageChange}
+				/>
+				<PageSizeSelector currentSize={pageSize} onSizeChange={onPageSizeChange} />
+			</div>
+		{/if}
 	</div>
 
 	<!-- Mobile content area - 保持原有行为 -->
@@ -178,6 +278,17 @@
 					</button>
 				{/each}
 			</div>
+
+				{#if sidAnchor && canShiftBackward}
+					<!-- Mobile browses forward with infinite scroll, backward needs an explicit step -->
+					<button
+						type="button"
+						class="btn btn-sm btn-outline mb-4 w-full"
+						onclick={() => onShiftSidWindow?.(-1)}
+					>
+						‹ {m['app.player.neighbors.previousWindow']({ count: pageSize })}
+					</button>
+				{/if}
 
 				{#each mobilePaginatedPlayers as item (item.id)}
 					<div class="collapse collapse-arrow bg-base-100 border-base-300 mb-3 border">
@@ -245,6 +356,28 @@
 									</button>
 								</div>
 							</div>
+
+							{#if onFindNeighbors}
+								<!-- Similar accounts entry point (mobile equivalent of the table action) -->
+								<div class="border-base-200 mt-3 pt-3 border-t">
+									<div class="flex items-center justify-between">
+										<span class="text-base-content/70 min-w-20 flex-shrink-0 text-sm">
+											<TranslatedText key="app.player.neighbors.label" />:
+										</span>
+										<button
+											class="btn btn-sm btn-outline"
+											onclick={(e) => {
+												e.stopPropagation();
+												onFindNeighbors(item);
+											}}
+											type="button"
+										>
+											<Users class="w-3 h-3 mr-1" />
+											<TranslatedText key="app.player.neighbors.button" />
+										</button>
+									</div>
+								</div>
+							{/if}
 						</div>
 					</div>
 				</div>

--- a/src/lib/models/player.model.ts
+++ b/src/lib/models/player.model.ts
@@ -6,22 +6,51 @@ export enum PlayerDatabase {
 	PRERESET_INVASION = 'prereset_invasion'
 }
 
-export type PlayerSortField =
-	| 'rank_progression'
-	| 'username'
-	| 'kills'
-	| 'deaths'
-	| 'kd'
-	| 'score'
-	| 'time_played'
-	| 'teamkills'
-	| 'longest_kill_streak'
-	| 'targets_destroyed'
-	| 'vehicles_destroyed'
-	| 'soldiers_healed'
-	| 'distance_moved'
-	| 'shots_fired'
-	| 'throwables_thrown';
+/**
+ * Sort fields accepted by the upstream player list endpoint.
+ *
+ * `sid` is undocumented and has no matching table column: upstream orders rows by the
+ * player's Steam ID but never returns the value, so it can only be used as an ordering.
+ * An unknown value makes upstream answer with an empty table, so every sort value that
+ * reaches the API must be validated against this list.
+ */
+export const PLAYER_SORT_FIELDS = [
+	'rank_progression',
+	'username',
+	'kills',
+	'deaths',
+	'kd',
+	'score',
+	'time_played',
+	'teamkills',
+	'longest_kill_streak',
+	'targets_destroyed',
+	'vehicles_destroyed',
+	'soldiers_healed',
+	'distance_moved',
+	'shots_fired',
+	'throwables_thrown',
+	'sid'
+] as const;
+
+export type PlayerSortField = (typeof PLAYER_SORT_FIELDS)[number];
+
+/** Sort field behind the "similar accounts" feature. */
+export const SID_SORT_FIELD: PlayerSortField = 'sid';
+
+export function isPlayerSortField(value: unknown): value is PlayerSortField {
+	return typeof value === 'string' && (PLAYER_SORT_FIELDS as readonly string[]).includes(value);
+}
+
+/**
+ * Convert a table column key (camelCase) to the upstream snake_case sort field.
+ * Returns undefined for keys the API does not accept (e.g. server table columns
+ * arriving through a shared `sort` URL parameter).
+ */
+export function toPlayerSortField(columnKey: string): PlayerSortField | undefined {
+	const snakeCase = columnKey.replace(/([A-Z])/g, '_$1').toLowerCase();
+	return isPlayerSortField(snakeCase) ? snakeCase : undefined;
+}
 
 export interface IPlayerListParams {
 	search?: string;

--- a/src/lib/services/user-settings.ts
+++ b/src/lib/services/user-settings.ts
@@ -45,7 +45,9 @@ const DEFAULT_SETTINGS: UserSettings = {
 		kd: true,
 		timePlayed: true,
 		rankProgression: true,
-		rankName: true
+		rankName: true,
+		// Row actions (share, similar accounts) - matches the server table default
+		action: true
 	},
 	layoutMode: 'fullPage' as const
 };

--- a/src/lib/stores/use-player-state.svelte.ts
+++ b/src/lib/stores/use-player-state.svelte.ts
@@ -1,5 +1,6 @@
 import { PlayerService } from '$lib/services/players';
 import type { IPlayerItem, PlayerDatabase, PlayerSortField } from '$lib/models/player.model';
+import { SID_SORT_FIELD, toPlayerSortField } from '$lib/models/player.model';
 
 interface PlayerStats {
 	totalPlayers: number;
@@ -48,6 +49,17 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	let playerSortColumn = $state<string | null>(null);
 	let playerSortDirection = $state<'asc' | 'desc' | null>(null);
 
+	// "Similar accounts" (SID) neighbor mode state.
+	// Upstream orders by Steam ID but never returns the value, so the window is positioned
+	// by anchoring on a username: when `search` is present upstream ignores `start` and
+	// answers with the window that begins 10 rows before the matched player.
+	let sidAnchor = $state<string | null>(null);
+	// Absolute start once the user shifts the window; overrides anchor positioning because
+	// `start` only works when no `search` is sent.
+	let sidWindowStart = $state<number | null>(null);
+	// Upstream answers with the first page instead of an error when the anchor is unknown.
+	let sidAnchorMissing = $state(false);
+
 	// Calculate statistics
 	const calculatePlayerStats = (
 		playerList: IPlayerItem[],
@@ -60,24 +72,55 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	};
 
 	/**
+	 * Resolve the sort field sent to the API.
+	 * Neighbor mode always sorts by SID; otherwise the column key is converted and
+	 * validated, because an unknown sort value makes upstream return an empty table.
+	 */
+	function resolveSortParam(): PlayerSortField | undefined {
+		if (sidAnchor !== null) {
+			return SID_SORT_FIELD;
+		}
+		return playerSortColumn ? toPlayerSortField(playerSortColumn) : undefined;
+	}
+
+	/**
+	 * Absolute start of the currently loaded window, derived from the upstream row numbers.
+	 */
+	function loadedWindowStart(): number {
+		const firstRowNumber = players[0]?.rowNumber ?? 1;
+		return Math.max(0, firstRowNumber - 1);
+	}
+
+	/**
 	 * Load players from API
 	 */
 	async function loadPlayers(options: LoadPlayersOptions = {}): Promise<void> {
 		const searchQuery = options.searchQuery ?? '';
-		const start = options.start ?? (currentPage - 1) * playerPageSize;
+		// The anchored request must not send `start` - upstream would ignore it anyway and
+		// the window it picks is the whole point of the anchor.
+		// Snapshot the anchor: concurrent loads may clear it before this request resolves
+		const requestAnchor = sidWindowStart === null ? sidAnchor : null;
+		const anchored = requestAnchor !== null;
 
 		try {
 			// Always use loading state for consistent UI
 			loading = true;
 
-			// Convert camelCase to snake_case for API
-			const sortParam: PlayerSortField | undefined = playerSortColumn
-				? (playerSortColumn.replace(/([A-Z])/g, '_$1').toLowerCase() as PlayerSortField)
-				: undefined;
+			const sortParam = resolveSortParam();
+			// Neighbor mode never forwards the user's search: any `search` value makes upstream
+			// ignore `start`, which would snap the window back to the searched player
+			const search = anchored
+				? requestAnchor
+				: sidAnchor !== null
+					? undefined
+					: searchQuery.trim() || undefined;
+			const start = anchored
+				? undefined
+				: (sidWindowStart ?? options.start ?? (currentPage - 1) * playerPageSize);
 
 			const result = await PlayerService.listWithPagination({
 				db: playerDb,
-				search: searchQuery.trim() || undefined,
+				search,
 				sort: sortParam,
 				size: playerPageSize,
 				start
@@ -88,6 +131,20 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 			playerHasPrevious = result.hasPrevious;
 			mobilePlayerCurrentPage = 1;
 			lastQueryTimestamp = Date.now();
+
+			if (anchored) {
+				const anchorLower = requestAnchor.toLowerCase();
+				const anchorFound = result.players.some(
+					(player) => (player.username ?? '').toLowerCase() === anchorLower
+				);
+				if (!anchorFound) {
+					// Upstream silently fell back to the first page: leave neighbor mode and
+					// surface it, the rows on screen are not this player's neighbors.
+					sidAnchorMissing = true;
+					sidAnchor = null;
+					sidWindowStart = null;
+				}
+			}
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to load player data';
 			console.error('Error loading players:', err);
@@ -101,16 +158,18 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	 */
 	async function loadPlayersMore(searchQuery: string = ''): Promise<void> {
 		try {
-			const start = (mobilePlayerCurrentPage - 1) * playerPageSize;
+			const inNeighborMode = sidAnchor !== null;
+			// In neighbor mode the next slice is an absolute offset from the loaded window and
+			// must be requested without `search`, otherwise upstream ignores `start`.
+			const start = inNeighborMode
+				? loadedWindowStart() + (mobilePlayerCurrentPage - 1) * playerPageSize
+				: (mobilePlayerCurrentPage - 1) * playerPageSize;
 
-			// Convert camelCase to snake_case for API
-			const sortParam: PlayerSortField | undefined = playerSortColumn
-				? (playerSortColumn.replace(/([A-Z])/g, '_$1').toLowerCase() as PlayerSortField)
-				: undefined;
+			const sortParam = resolveSortParam();
 
 			const result = await PlayerService.listWithPagination({
 				db: playerDb,
-				search: searchQuery.trim() || undefined,
+				search: inNeighborMode ? undefined : searchQuery.trim() || undefined,
 				sort: sortParam,
 				size: playerPageSize,
 				start
@@ -129,6 +188,10 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	 * Handle sort column change
 	 */
 	function handleSort(column: string): void {
+		// Sorting by a visible column leaves the SID neighbor window
+		sidAnchor = null;
+		sidWindowStart = null;
+
 		// Toggle sort: if clicking same column, clear it; otherwise set to desc
 		if (playerSortColumn === column) {
 			playerSortColumn = null;
@@ -141,6 +204,53 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 		currentPage = 1;
 		mobilePlayerCurrentPage = 1;
 		mobilePlayerLoadingMore = false;
+	}
+
+	/**
+	 * Enter "similar accounts" mode: order by SID and position the window on this player.
+	 */
+	function enterSidNeighborMode(username: string): void {
+		sidAnchor = username;
+		sidWindowStart = null;
+		sidAnchorMissing = false;
+		playerSortColumn = SID_SORT_FIELD;
+		// Upstream accepts no direction for sid, so no arrow state is claimed
+		playerSortDirection = null;
+		currentPage = 1;
+		mobilePlayerCurrentPage = 1;
+		mobilePlayerLoadingMore = false;
+	}
+
+	/**
+	 * Leave "similar accounts" mode and drop the SID ordering, which is meaningless on its own.
+	 */
+	function exitSidNeighborMode(): void {
+		sidAnchor = null;
+		sidWindowStart = null;
+		sidAnchorMissing = false;
+		if (playerSortColumn === SID_SORT_FIELD) {
+			playerSortColumn = null;
+			playerSortDirection = null;
+		}
+		currentPage = 1;
+		mobilePlayerCurrentPage = 1;
+		mobilePlayerLoadingMore = false;
+	}
+
+	/**
+	 * Move the neighbor window one page up or down.
+	 * Uses the absolute row numbers of the loaded window because the anchored request
+	 * cannot be paginated (upstream ignores `start` while `search` is present).
+	 */
+	function shiftSidWindow(direction: 1 | -1): void {
+		const nextStart = Math.max(0, loadedWindowStart() + direction * playerPageSize);
+		sidWindowStart = nextStart;
+		mobilePlayerCurrentPage = 1;
+		mobilePlayerLoadingMore = false;
+	}
+
+	function dismissSidAnchorMissing(): void {
+		sidAnchorMissing = false;
 	}
 
 	/**
@@ -169,6 +279,10 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	 */
 	function handlePlayerDbChange(db: PlayerDatabase): void {
 		playerDb = db;
+		// Row positions differ per database: re-anchor instead of keeping the old offset
+		if (sidAnchor !== null) {
+			sidWindowStart = null;
+		}
 	}
 
 	/**
@@ -229,6 +343,13 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	 * Set sort state directly (useful for URL state sync)
 	 */
 	function setSortState(column: string | null, direction: 'asc' | 'desc' | null): void {
+		// The `sort` URL parameter is shared with the server table, whose column keys the
+		// player API rejects with an empty table - ignore anything it cannot sort by.
+		if (column !== null && toPlayerSortField(column) === undefined) {
+			playerSortColumn = null;
+			playerSortDirection = null;
+			return;
+		}
 		playerSortColumn = column;
 		playerSortDirection = direction;
 	}
@@ -277,11 +398,24 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 		get lastQueryTimestamp() {
 			return lastQueryTimestamp;
 		},
+		get sidAnchor() {
+			return sidAnchor;
+		},
+		get sidNeighborMode() {
+			return sidAnchor !== null;
+		},
+		get sidAnchorMissing() {
+			return sidAnchorMissing;
+		},
 
 		// Methods
 		loadPlayers,
 		loadPlayersMore,
 		handleSort,
+		enterSidNeighborMode,
+		exitSidNeighborMode,
+		shiftSidWindow,
+		dismissSidAnchorMissing,
 		handlePageChange,
 		handleLoadMore,
 		handlePlayerDbChange,

--- a/src/lib/stores/use-player-state.svelte.ts
+++ b/src/lib/stores/use-player-state.svelte.ts
@@ -60,6 +60,18 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	// Upstream answers with the first page instead of an error when the anchor is unknown.
 	let sidAnchorMissing = $state(false);
 
+	// Query generation: responses that no longer match the current query are dropped, so a
+	// slow request cannot overwrite the window, append foreign rows or clear neighbor mode
+	// after the user moved on.
+	let queryGeneration = 0;
+
+	/**
+	 * Invalidate every in-flight request, e.g. after the query state changed.
+	 */
+	function invalidateInFlightRequests(): void {
+		queryGeneration++;
+	}
+
 	// Calculate statistics
 	const calculatePlayerStats = (
 		playerList: IPlayerItem[],
@@ -101,6 +113,7 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 		// Snapshot the anchor: concurrent loads may clear it before this request resolves
 		const requestAnchor = sidWindowStart === null ? sidAnchor : null;
 		const anchored = requestAnchor !== null;
+		const generation = ++queryGeneration;
 
 		try {
 			// Always use loading state for consistent UI
@@ -126,6 +139,11 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 				start
 			});
 
+			// A newer query started while this one was in flight
+			if (generation !== queryGeneration) {
+				return;
+			}
+
 			players = result.players;
 			playerHasNext = result.hasNext;
 			playerHasPrevious = result.hasPrevious;
@@ -140,16 +158,25 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 				if (!anchorFound) {
 					// Upstream silently fell back to the first page: leave neighbor mode and
 					// surface it, the rows on screen are not this player's neighbors.
+					// The SID ordering is deliberately kept (unlike exitSidNeighborMode): those
+					// rows really are SID-ordered, so the banner stays truthful and offers the
+					// explicit exit. Clearing it here would leave an unexplained ordering.
 					sidAnchorMissing = true;
 					sidAnchor = null;
 					sidWindowStart = null;
 				}
 			}
 		} catch (err) {
+			if (generation !== queryGeneration) {
+				return;
+			}
 			error = err instanceof Error ? err.message : 'Failed to load player data';
 			console.error('Error loading players:', err);
 		} finally {
-			loading = false;
+			// Only the newest query owns the loading indicator
+			if (generation === queryGeneration) {
+				loading = false;
+			}
 		}
 	}
 
@@ -157,6 +184,8 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	 * Load more players for mobile infinite scroll
 	 */
 	async function loadPlayersMore(searchQuery: string = ''): Promise<void> {
+		const generation = queryGeneration;
+
 		try {
 			const inNeighborMode = sidAnchor !== null;
 			// In neighbor mode the next slice is an absolute offset from the loaded window and
@@ -175,10 +204,18 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 				start
 			});
 
+			// The window moved on: appending these rows would mix two different queries
+			if (generation !== queryGeneration) {
+				return;
+			}
+
 			players = [...players, ...result.players];
 			playerHasNext = result.hasNext;
 			playerHasPrevious = result.hasPrevious;
 		} catch (err) {
+			if (generation !== queryGeneration) {
+				return;
+			}
 			error = err instanceof Error ? err.message : 'Failed to load player data';
 			console.error('Error loading players:', err);
 		}
@@ -188,6 +225,7 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	 * Handle sort column change
 	 */
 	function handleSort(column: string): void {
+		invalidateInFlightRequests();
 		// Sorting by a visible column leaves the SID neighbor window
 		sidAnchor = null;
 		sidWindowStart = null;
@@ -210,6 +248,7 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	 * Enter "similar accounts" mode: order by SID and position the window on this player.
 	 */
 	function enterSidNeighborMode(username: string): void {
+		invalidateInFlightRequests();
 		sidAnchor = username;
 		sidWindowStart = null;
 		sidAnchorMissing = false;
@@ -225,6 +264,7 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	 * Leave "similar accounts" mode and drop the SID ordering, which is meaningless on its own.
 	 */
 	function exitSidNeighborMode(): void {
+		invalidateInFlightRequests();
 		sidAnchor = null;
 		sidWindowStart = null;
 		sidAnchorMissing = false;
@@ -243,6 +283,7 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	 * cannot be paginated (upstream ignores `start` while `search` is present).
 	 */
 	function shiftSidWindow(direction: 1 | -1): void {
+		invalidateInFlightRequests();
 		const nextStart = Math.max(0, loadedWindowStart() + direction * playerPageSize);
 		sidWindowStart = nextStart;
 		mobilePlayerCurrentPage = 1;
@@ -257,6 +298,7 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	 * Handle page change
 	 */
 	function handlePageChange(page: number): void {
+		invalidateInFlightRequests();
 		currentPage = page;
 	}
 
@@ -278,6 +320,7 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	 * Handle player database change
 	 */
 	function handlePlayerDbChange(db: PlayerDatabase): void {
+		invalidateInFlightRequests();
 		playerDb = db;
 		// Row positions differ per database: re-anchor instead of keeping the old offset
 		if (sidAnchor !== null) {
@@ -289,6 +332,7 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	 * Handle player page size change
 	 */
 	function handlePlayerPageSizeChange(size: number): void {
+		invalidateInFlightRequests();
 		playerPageSize = size;
 		currentPage = 1;
 		mobilePlayerCurrentPage = 1;

--- a/src/lib/stores/use-player-state.svelte.ts
+++ b/src/lib/stores/use-player-state.svelte.ts
@@ -64,6 +64,9 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	// slow request cannot overwrite the window, append foreign rows or clear neighbor mode
 	// after the user moved on.
 	let queryGeneration = 0;
+	// Requests in flight. The loading flag follows this count instead of the generation, so a
+	// dropped stale response still clears it when nothing else is loading.
+	let activeRequests = 0;
 
 	/**
 	 * Invalidate every in-flight request, e.g. after the query state changed.
@@ -117,6 +120,7 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 
 		try {
 			// Always use loading state for consistent UI
+			activeRequests++;
 			loading = true;
 
 			const sortParam = resolveSortParam();
@@ -173,8 +177,8 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 			error = err instanceof Error ? err.message : 'Failed to load player data';
 			console.error('Error loading players:', err);
 		} finally {
-			// Only the newest query owns the loading indicator
-			if (generation === queryGeneration) {
+			activeRequests--;
+			if (activeRequests === 0) {
 				loading = false;
 			}
 		}
@@ -389,13 +393,17 @@ export function createPlayerState(initialDb: PlayerDatabase = 'invasion' as Play
 	function setSortState(column: string | null, direction: 'asc' | 'desc' | null): void {
 		// The `sort` URL parameter is shared with the server table, whose column keys the
 		// player API rejects with an empty table - ignore anything it cannot sort by.
-		if (column !== null && toPlayerSortField(column) === undefined) {
-			playerSortColumn = null;
-			playerSortDirection = null;
-			return;
+		const nextColumn = column !== null && toPlayerSortField(column) === undefined ? null : column;
+		const nextDirection = nextColumn === null ? null : direction;
+
+		// A different effective sort makes any in-flight response belong to the previous query.
+		// URL sync calls this on every history update, so an unchanged sort must not invalidate.
+		if (playerSortColumn !== nextColumn || playerSortDirection !== nextDirection) {
+			invalidateInFlightRequests();
 		}
-		playerSortColumn = column;
-		playerSortDirection = direction;
+
+		playerSortColumn = nextColumn;
+		playerSortDirection = nextDirection;
 	}
 
 	return {

--- a/src/lib/stores/use-url-sync.svelte.ts
+++ b/src/lib/stores/use-url-sync.svelte.ts
@@ -75,11 +75,10 @@ export function createUrlSync(options: UrlSyncOptions) {
 			quickFilters.some((filter) => filter.id === filterId)
 		);
 
-		// Sort state change - sync to both states
-		if (urlState.sortColumn !== undefined) {
-			serverState.setSortState(urlState.sortColumn, urlState.sortDirection || null);
-			playerState.setSortState(urlState.sortColumn, urlState.sortDirection || null);
-		}
+		// Sort state change - sync to both states. The URL is authoritative here, so a URL
+		// without `sort` (e.g. after browser Back) has to clear the previous sort as well.
+		serverState.setSortState(urlState.sortColumn ?? null, urlState.sortDirection || null);
+		playerState.setSortState(urlState.sortColumn ?? null, urlState.sortDirection || null);
 
 		// Similar accounts anchor change (browser back/forward on a shared window)
 		if (urlState.sidAnchor) {

--- a/src/lib/stores/use-url-sync.svelte.ts
+++ b/src/lib/stores/use-url-sync.svelte.ts
@@ -44,7 +44,8 @@ export function createUrlSync(options: UrlSyncOptions) {
 			);
 		}
 
-		// Initialize sort state - apply to both server and player states
+		// Initialize sort state - apply to both server and player states.
+		// playerState drops values its API cannot sort by (e.g. server column keys).
 		if (urlState.sortColumn && urlState.sortDirection) {
 			serverState.setSortState(urlState.sortColumn, urlState.sortDirection);
 			playerState.setSortState(urlState.sortColumn, urlState.sortDirection);
@@ -67,19 +68,26 @@ export function createUrlSync(options: UrlSyncOptions) {
 			onSearchChange(urlState.search);
 		}
 
-		// Quick filters change
-		if (urlState.quickFilters !== undefined) {
-			const validFilters = urlState.quickFilters.filter((filterId) =>
-				quickFilters.some((filter) => filter.id === filterId)
-			);
-			// Return for component to handle
-			return { quickFilters: validFilters };
-		}
+		// Quick filters change - returned at the end so the remaining state still syncs
+		// (the URL subscriber always sends a quickFilters array, so returning here would
+		// make every state change below unreachable)
+		const validFilters = urlState.quickFilters?.filter((filterId) =>
+			quickFilters.some((filter) => filter.id === filterId)
+		);
 
 		// Sort state change - sync to both states
 		if (urlState.sortColumn !== undefined) {
 			serverState.setSortState(urlState.sortColumn, urlState.sortDirection || null);
 			playerState.setSortState(urlState.sortColumn, urlState.sortDirection || null);
+		}
+
+		// Similar accounts anchor change (browser back/forward on a shared window)
+		if (urlState.sidAnchor) {
+			if (urlState.sidAnchor !== playerState.sidAnchor) {
+				playerState.enterSidNeighborMode(urlState.sidAnchor);
+			}
+		} else if (playerState.sidNeighborMode) {
+			playerState.exitSidNeighborMode();
 		}
 
 		// View mode change
@@ -96,7 +104,7 @@ export function createUrlSync(options: UrlSyncOptions) {
 			}
 		}
 
-		return {};
+		return validFilters !== undefined ? { quickFilters: validFilters } : {};
 	}
 
 	/**

--- a/src/lib/types/analytics.ts
+++ b/src/lib/types/analytics.ts
@@ -26,6 +26,8 @@ export type AnalyticsEventName =
 	| 'load_more_click'
 	| 'auto_refresh_toggle'
 	| 'player_database_change'
+	| 'player_find_neighbors'
+	| 'player_neighbors_shift'
 	// Share Events
 	| 'share_modal_open'
 	| 'share_download'

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -177,6 +177,8 @@ class Analytics {
 		if (params.image_format) labelParts.push(`format:${params.image_format}`);
 		if (params.share_type) labelParts.push(`type:${params.share_type}`);
 		if (params.method) labelParts.push(`method:${params.method}`);
+		// Baidu reuses the event name as its action, so the param needs its own label part
+		if (params.action) labelParts.push(`action:${params.action}`);
 
 		return {
 			category,

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -43,6 +43,8 @@ const BAIDU_CATEGORIES = {
 	load_more_click: 'data',
 	auto_refresh_toggle: 'data',
 	player_database_change: 'data',
+	player_find_neighbors: 'data',
+	player_neighbors_shift: 'data',
 	share_modal_open: 'share',
 	share_download: 'share',
 	share_copy: 'share',

--- a/src/lib/utils/url-state.ts
+++ b/src/lib/utils/url-state.ts
@@ -11,7 +11,8 @@ export const URL_PARAMS = {
 	SORT_COLUMN: 'sort',
 	SORT_DIRECTION: 'dir',
 	VIEW: 'view',
-	PLAYER_DB: 'db'
+	PLAYER_DB: 'db',
+	SID_ANCHOR: 'anchor'
 } as const;
 
 // URL状态管理接口
@@ -23,6 +24,8 @@ export interface UrlState {
 	sortDirection?: 'asc' | 'desc';
 	view?: 'servers' | 'players';
 	playerDb?: PlayerDatabase;
+	/** Username the "similar accounts" (SID) window is anchored on */
+	sidAnchor?: string;
 }
 
 // 从URL获取查询参数
@@ -72,6 +75,12 @@ export function getUrlState(): UrlState {
 	const playerDb = urlParams.get(URL_PARAMS.PLAYER_DB);
 	if (playerDb === 'invasion' || playerDb === 'pacific' || playerDb === 'prereset_invasion') {
 		state.playerDb = playerDb as PlayerDatabase;
+	}
+
+	// 相近账号锚点玩家
+	const sidAnchor = urlParams.get(URL_PARAMS.SID_ANCHOR);
+	if (sidAnchor) {
+		state.sidAnchor = sidAnchor;
 	}
 
 	return state;
@@ -145,6 +154,15 @@ export function updateUrlState(state: Partial<UrlState>, replace: boolean = fals
 		}
 	}
 
+	// 更新相近账号锚点
+	if ('sidAnchor' in state) {
+		if (state.sidAnchor) {
+			urlParams.set(URL_PARAMS.SID_ANCHOR, state.sidAnchor);
+		} else {
+			urlParams.delete(URL_PARAMS.SID_ANCHOR);
+		}
+	}
+
 	// 构建新的URL
 	const newUrl = `${window.location.pathname}${urlParams.toString() ? '?' + urlParams.toString() : ''}`;
 
@@ -164,7 +182,8 @@ export function clearUrlState(): void {
 			quickFilters: [],
 			page: undefined,
 			sortColumn: undefined,
-			sortDirection: undefined
+			sortDirection: undefined,
+			sidAnchor: undefined
 		},
 		true
 	);
@@ -196,7 +215,8 @@ export function createUrlStateSubscriber(callback: (state: UrlState) => void) {
 			view:
 				($page.url.searchParams.get(URL_PARAMS.VIEW) as 'servers' | 'players' | null) || undefined,
 			playerDb:
-				($page.url.searchParams.get(URL_PARAMS.PLAYER_DB) as PlayerDatabase | null) || undefined
+				($page.url.searchParams.get(URL_PARAMS.PLAYER_DB) as PlayerDatabase | null) || undefined,
+			sidAnchor: $page.url.searchParams.get(URL_PARAMS.SID_ANCHOR) || undefined
 		};
 		callback(state);
 	});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -526,8 +526,19 @@
 	function handleViewChange(view: 'servers' | 'players') {
 		currentView = view;
 		searchQuery = '';
+		// Dropping the SID ordering in state must drop it from the URL too, otherwise a
+		// reload or a shared link restores a mode the user just left
+		const leavingSidMode = playerState.playerSortColumn === SID_SORT_FIELD;
 		playerState.exitSidNeighborMode();
-		updateUrlState({ view, search: undefined, sidAnchor: undefined }, true);
+		updateUrlState(
+			{
+				view,
+				search: undefined,
+				sidAnchor: undefined,
+				...(leavingSidMode ? { sortColumn: undefined, sortDirection: undefined } : {})
+			},
+			true
+		);
 		serverState.resetPagination();
 		playerState.resetPagination();
 		if (view === 'players') {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
 	import { columns } from '$lib/config/server-columns';
 	import { getMaps, type MapData } from '$lib/services/maps';
 	import type { IPlayerColumn, PlayerDatabase, PlayerSortField } from '$lib/models/player.model';
+	import { SID_SORT_FIELD } from '$lib/models/player.model';
 	import { playerColumns } from '$lib/config/player-columns';
 	import { PlayerService } from '$lib/services/players';
 	import {
@@ -67,11 +68,24 @@
 	let highlightedUsername = $state<string | undefined>(undefined);
 
 	// Update highlighted username when search changes
+	// The SID anchor wins: in neighbor mode the anchored player is what the window is about
 	$effect(() => {
-		if (searchQuery && currentView === 'players') {
+		if (currentView !== 'players') {
+			highlightedUsername = undefined;
+		} else if (playerState.sidAnchor) {
+			highlightedUsername = playerState.sidAnchor;
+		} else if (searchQuery) {
 			highlightedUsername = searchQuery.trim();
 		} else {
 			highlightedUsername = undefined;
+		}
+	});
+
+	// A missing anchor left neighbor mode, so drop it from the URL as well - otherwise a
+	// shared link would keep re-entering a window that cannot be positioned
+	$effect(() => {
+		if (playerState.sidAnchorMissing) {
+			updateUrlState({ sidAnchor: undefined }, true);
 		}
 	});
 
@@ -126,9 +140,21 @@
 		analytics.trackSearch('keyboard');
 	}
 
+	/**
+	 * A user-driven search replaces the SID anchor: both position the same window upstream,
+	 * so keeping neighbor mode would silently ignore what was typed.
+	 */
+	function leaveSidModeForSearch(): boolean {
+		if (!playerState.sidNeighborMode) return false;
+		playerState.exitSidNeighborMode();
+		updateUrlState({ sidAnchor: undefined, sortColumn: undefined, sortDirection: undefined }, true);
+		return true;
+	}
+
 	function handleSearchEnter(value: string) {
 		if (currentView === 'players') {
 			searchQuery = value;
+			leaveSidModeForSearch();
 			serverState.resetPagination();
 			playerState.resetPagination();
 			updateUrlState({ search: value.trim() || undefined }, true);
@@ -146,9 +172,14 @@
 
 	function handleSearchClear() {
 		searchQuery = '';
+		const leftSidMode = leaveSidModeForSearch();
 		serverState.resetPagination();
 		playerState.resetPagination();
 		updateUrlState({ search: undefined }, true);
+		// Leaving neighbor mode changes the ordering, so the visible rows are now stale
+		if (leftSidMode) {
+			playerState.loadPlayers({ searchQuery: '' });
+		}
 		analytics.trackSearch('click');
 	}
 
@@ -265,6 +296,50 @@
 		}
 		playerState.loadPlayers({ searchQuery });
 		analytics.trackColumnSort(column, playerState.playerSortDirection || 'asc');
+	}
+
+	/**
+	 * Enter "similar accounts" mode for a player: SID ordering anchored on their row.
+	 */
+	function handleFindNeighbors(player: import('$lib/models/player.model').IPlayerItem) {
+		playerState.enterSidNeighborMode(player.username);
+		updateUrlState(
+			{
+				sortColumn: playerState.playerSortColumn ?? undefined,
+				sortDirection: undefined,
+				sidAnchor: player.username,
+				page: undefined
+			},
+			true
+		);
+		playerState.loadPlayers({ searchQuery });
+		analytics.trackEvent('player_find_neighbors', { player_database: playerState.playerDb });
+	}
+
+	function handleExitSidMode() {
+		playerState.exitSidNeighborMode();
+		updateUrlState(
+			{
+				sortColumn: undefined,
+				sortDirection: undefined,
+				sidAnchor: undefined,
+				page: undefined
+			},
+			true
+		);
+		playerState.loadPlayers({ searchQuery });
+	}
+
+	function handleShiftSidWindow(direction: 1 | -1) {
+		playerState.shiftSidWindow(direction);
+		playerState.loadPlayers({ searchQuery });
+		analytics.trackEvent('player_neighbors_shift', {
+			action: direction > 0 ? 'next' : 'previous'
+		});
+	}
+
+	function handleDismissSidAnchorMissing() {
+		playerState.dismissSidAnchorMissing();
 	}
 
 	function toggleMobileCard(id: string) {
@@ -418,7 +493,9 @@
 				shots_fired: 'shotsFired',
 				throwables_thrown: 'throwablesThrown',
 				rank_progression: 'rankProgression',
-				username: 'username'
+				username: 'username',
+				// SID has no column and no meaningful ranking, it is never queried here
+				sid: 'sid'
 			};
 			return keyMap[sortField] || sortField;
 		}
@@ -449,7 +526,8 @@
 	function handleViewChange(view: 'servers' | 'players') {
 		currentView = view;
 		searchQuery = '';
-		updateUrlState({ view, search: undefined }, true);
+		playerState.exitSidNeighborMode();
+		updateUrlState({ view, search: undefined, sidAnchor: undefined }, true);
 		serverState.resetPagination();
 		playerState.resetPagination();
 		if (view === 'players') {
@@ -503,6 +581,10 @@
 		}
 		if (urlInit.initialPlayerDb) {
 			playerState.handlePlayerDbChange(urlInit.initialPlayerDb);
+		}
+		// A shared "similar accounts" link restores the anchored SID window
+		if (urlState.sidAnchor) {
+			playerState.enterSidNeighborMode(urlState.sidAnchor);
 		}
 	}
 
@@ -658,12 +740,19 @@
 				{layoutMode}
 				hasNext={playerState.playerHasNext}
 				hasPrevious={playerState.playerHasPrevious}
+				sidAnchor={playerState.sidAnchor}
+				sidSortActive={playerState.playerSortColumn === SID_SORT_FIELD}
+				sidAnchorMissing={playerState.sidAnchorMissing}
 				onSort={handlePlayerSort}
 				onPageChange={handlePageChange}
 				onPageSizeChange={handlePlayerPageSizeChange}
 				onLoadMore={handleLoadMore}
 				onToggleMobileCard={toggleMobileCard}
 				onShare={handlePlayerShare}
+				onFindNeighbors={handleFindNeighbors}
+				onExitSidMode={handleExitSidMode}
+				onShiftSidWindow={handleShiftSidWindow}
+				onDismissSidAnchorMissing={handleDismissSidAnchorMissing}
 			/>
 		{/if}
 	</div>

--- a/tests/e2e/mock-server.cjs
+++ b/tests/e2e/mock-server.cjs
@@ -48,6 +48,142 @@ const mockServerListResponse = `<?xml version="1.0" encoding="UTF-8"?>
   </server>
 </result>`;
 
+// --- Player list mock -------------------------------------------------------
+// Mirrors the quirks of rwr_stats/view_players.php that the app depends on:
+// - `sort` values outside the known list produce an empty table
+// - `sort=sid` orders rows by an id the response never contains
+// - when `search` is present `start` is ignored and the window begins 10 rows
+//   before the matched player; an unknown name silently falls back to rank 1
+const MOCK_PLAYER_COUNT = 60;
+const PLAYER_SORT_FIELDS = [
+	'rank_progression',
+	'username',
+	'kills',
+	'deaths',
+	'kd',
+	'score',
+	'time_played',
+	'teamkills',
+	'longest_kill_streak',
+	'targets_destroyed',
+	'vehicles_destroyed',
+	'soldiers_healed',
+	'distance_moved',
+	'shots_fired',
+	'throwables_thrown',
+	'sid'
+];
+
+const mockPlayers = Array.from({ length: MOCK_PLAYER_COUNT }, (_, i) => ({
+	username: `MockPlayer${i + 1}`,
+	kills: 1000 - i * 7,
+	deaths: 500 - i * 3,
+	score: 900 - i * 5,
+	kd: (2 + (i % 10) / 10).toFixed(2),
+	timePlayed: `${20 + i}h 10min`,
+	longestKillStreak: 50 - (i % 20),
+	targetsDestroyed: i % 7,
+	vehiclesDestroyed: i % 5,
+	soldiersHealed: i % 11,
+	teamkills: i % 3,
+	distanceMoved: `${100 + i}.5km`,
+	shotsFired: 20000 - i * 13,
+	throwablesThrown: i % 9,
+	rankProgression: 9000 - i * 41,
+	rankName: `Rank ${i % 12}`,
+	// Never rendered: upstream only orders by it. Coprime step, so sid ordering is a
+	// permutation that starts somewhere else than the default ordering.
+	sid: ((i + 1) * 7) % MOCK_PLAYER_COUNT
+}));
+
+function orderMockPlayers(sort) {
+	const ordered = [...mockPlayers];
+	if (sort === 'sid') {
+		return ordered.sort((a, b) => a.sid - b.sid);
+	}
+	if (sort === 'username') {
+		return ordered.sort((a, b) => a.username.localeCompare(b.username));
+	}
+	if (sort && sort !== 'rank_progression') {
+		return ordered.sort((a, b) => Number(b[sort] ?? 0) - Number(a[sort] ?? 0));
+	}
+	return ordered;
+}
+
+function renderPlayerRow(player, rowNumber, highlighted) {
+	const cells = [
+		rowNumber,
+		player.username,
+		player.kills,
+		player.deaths,
+		player.score,
+		player.kd,
+		player.timePlayed,
+		player.longestKillStreak,
+		player.targetsDestroyed,
+		player.vehiclesDestroyed,
+		player.soldiersHealed,
+		player.teamkills,
+		player.distanceMoved,
+		player.shotsFired,
+		player.throwablesThrown,
+		player.rankProgression,
+		player.rankName
+	];
+	const body = cells.map((value) => `<td>${value}</td>`).join('\n');
+	return `<tr class="${highlighted ? 'highlight' : ''}">${body}
+<td><img width="16" height="16" src="textures/hud_rank6.png" /></td>
+</tr>`;
+}
+
+function buildPlayerListResponse(query) {
+	const sort = typeof query.sort === 'string' ? query.sort : undefined;
+	const search = typeof query.search === 'string' ? query.search.trim() : '';
+	const size = Math.min(Math.max(parseInt(query.size, 10) || 100, 1), 100);
+	const requestedStart = Math.max(parseInt(query.start, 10) || 0, 0);
+
+	// Unknown sort field: upstream answers with a table that has no rows
+	if (sort !== undefined && !PLAYER_SORT_FIELDS.includes(sort)) {
+		return '<html><body><table>\n<tr><th>#</th></tr>\n</table></body></html>';
+	}
+
+	const ordered = orderMockPlayers(sort);
+
+	let start = requestedStart;
+	if (search) {
+		// `start` is ignored while searching; unknown names fall back to the first page
+		const hitIndex = ordered.findIndex(
+			(player) => player.username.toLowerCase() === search.toLowerCase()
+		);
+		start = hitIndex === -1 ? 0 : Math.max(0, hitIndex - 10);
+	}
+
+	const window = ordered.slice(start, start + size);
+	const rows = window
+		.map((player, index) =>
+			renderPlayerRow(
+				player,
+				start + index + 1,
+				Boolean(search) && player.username.toLowerCase() === search.toLowerCase()
+			)
+		)
+		.join('\n');
+
+	const links = [
+		start > 0 ? '<a href="?start=prev">Previous</a>' : '',
+		start + size < ordered.length ? '<a href="?start=next">Next</a>' : ''
+	]
+		.filter(Boolean)
+		.join('\n');
+
+	return `<html><body><table>
+<tr><th>#</th><th>Username</th><th>Kills</th></tr>
+${rows}
+</table>
+${links}
+</body></html>`;
+}
+
 // Create a simple HTTP server
 function startMockServer(port = 5800) {
 	const server = http.createServer((req, res) => {
@@ -61,6 +197,14 @@ function startMockServer(port = 5800) {
 			res.setHeader('Content-Type', 'application/xml');
 			res.writeHead(200);
 			res.end(mockServerListResponse);
+			return;
+		}
+
+		// Handle player_list endpoint
+		if (pathname === '/api/player_list') {
+			res.setHeader('Content-Type', 'text/html');
+			res.writeHead(200);
+			res.end(buildPlayerListResponse(parsedUrl.query || {}));
 			return;
 		}
 

--- a/tests/e2e/mock-server.cjs
+++ b/tests/e2e/mock-server.cjs
@@ -96,6 +96,25 @@ const mockPlayers = Array.from({ length: MOCK_PLAYER_COUNT }, (_, i) => ({
 	sid: ((i + 1) * 7) % MOCK_PLAYER_COUNT
 }));
 
+// API sort field -> comparable value of a mock player. Field names are snake_case while
+// the mock rows are camelCase, and some values carry units that have to be stripped.
+const SORT_VALUE_BY_FIELD = {
+	kills: (player) => player.kills,
+	deaths: (player) => player.deaths,
+	score: (player) => player.score,
+	kd: (player) => Number(player.kd),
+	time_played: (player) => parseInt(player.timePlayed, 10),
+	teamkills: (player) => player.teamkills,
+	longest_kill_streak: (player) => player.longestKillStreak,
+	targets_destroyed: (player) => player.targetsDestroyed,
+	vehicles_destroyed: (player) => player.vehiclesDestroyed,
+	soldiers_healed: (player) => player.soldiersHealed,
+	distance_moved: (player) => parseFloat(player.distanceMoved),
+	shots_fired: (player) => player.shotsFired,
+	throwables_thrown: (player) => player.throwablesThrown,
+	rank_progression: (player) => player.rankProgression
+};
+
 function orderMockPlayers(sort) {
 	const ordered = [...mockPlayers];
 	if (sort === 'sid') {
@@ -104,8 +123,9 @@ function orderMockPlayers(sort) {
 	if (sort === 'username') {
 		return ordered.sort((a, b) => a.username.localeCompare(b.username));
 	}
-	if (sort && sort !== 'rank_progression') {
-		return ordered.sort((a, b) => Number(b[sort] ?? 0) - Number(a[sort] ?? 0));
+	const getSortValue = sort ? SORT_VALUE_BY_FIELD[sort] : undefined;
+	if (getSortValue) {
+		return ordered.sort((a, b) => getSortValue(b) - getSortValue(a));
 	}
 	return ordered;
 }

--- a/tests/e2e/players-neighbors.test.ts
+++ b/tests/e2e/players-neighbors.test.ts
@@ -74,12 +74,15 @@ test('player list API honours the sid sort and rejects unknown sort values', asy
 	const defaultResponse = await request.get(
 		`${MOCK_API_URL}/api/player_list?db=invasion&start=0&size=20`
 	);
+	expect(defaultResponse.ok()).toBeTruthy();
 	const defaultHtml = await defaultResponse.text();
 	expect(defaultHtml).toMatch(/<td>1<\/td>\s*<td>MockPlayer1<\/td>/);
 
 	const brokenResponse = await request.get(
 		`${MOCK_API_URL}/api/player_list?db=invasion&sort=garbage`
 	);
+	// An unrouted endpoint would also answer without "MockPlayer", so check the status first
+	expect(brokenResponse.ok()).toBeTruthy();
 	const brokenHtml = await brokenResponse.text();
 	expect(brokenHtml).not.toContain('MockPlayer');
 });

--- a/tests/e2e/players-neighbors.test.ts
+++ b/tests/e2e/players-neighbors.test.ts
@@ -4,6 +4,16 @@ const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:5173';
 const MOCK_API_URL = process.env.E2E_MOCK_API_URL ?? 'http://localhost:5800';
 const PLAYERS_URL = `${BASE_URL}/?view=players`;
 
+/** Largest scroll offset anywhere on the page: the app may scroll an inner container. */
+function maxScrollTop(page: import('@playwright/test').Page): Promise<number> {
+	return page.evaluate(() =>
+		Math.max(
+			document.scrollingElement?.scrollTop ?? 0,
+			...Array.from(document.querySelectorAll('*')).map((element) => element.scrollTop)
+		)
+	);
+}
+
 test('similar accounts entry point anchors the SID window on a player', async ({ page }) => {
 	await page.goto(PLAYERS_URL);
 
@@ -58,6 +68,34 @@ test('unknown anchor reports the fallback instead of pretending to show neighbor
 	await expect(page.locator('[data-testid="sid-anchor-missing"]')).toBeVisible({ timeout: 10000 });
 	// Neighbor mode was left, so the window navigation is gone
 	await expect(page.locator('[data-testid="sid-window-nav"]')).toHaveCount(0);
+});
+
+test('desktop table scrolls the anchored row into view', async ({ page }) => {
+	// Short viewport: the anchored row sits below the fold in a 20-row window
+	await page.setViewportSize({ width: 1280, height: 400 });
+	await page.goto(`${PLAYERS_URL}&sort=sid&anchor=MockPlayer1`);
+
+	await expect(page.locator('[data-testid="sid-mode-banner"]')).toBeVisible({ timeout: 10000 });
+
+	const anchoredRow = page.locator('[id="player-row-invasion:MockPlayer1"]');
+	await expect(anchoredRow).toHaveClass(/highlighted-row/);
+	await expect(anchoredRow).toBeInViewport();
+	// It only got there by scrolling: without it the row is far below the fold
+	await expect.poll(() => maxScrollTop(page)).toBeGreaterThan(0);
+});
+
+test('mobile cards highlight the anchored player and scroll it into view', async ({ page }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.goto(`${PLAYERS_URL}&sort=sid&anchor=MockPlayer1`);
+
+	await expect(page.locator('[data-testid="sid-mode-banner"]')).toBeVisible({ timeout: 10000 });
+
+	const anchoredCard = page.locator('[id="player-mobile-card-invasion:MockPlayer1"]');
+	await expect(anchoredCard).toHaveClass(/highlighted-card/);
+	await expect(page.locator('.highlighted-card')).toHaveCount(1);
+	// The anchor sits below the fold in a 20-card window
+	await expect(anchoredCard).toBeInViewport();
+	await expect.poll(() => maxScrollTop(page)).toBeGreaterThan(0);
 });
 
 test('player list API honours the sid sort and rejects unknown sort values', async ({

--- a/tests/e2e/players-neighbors.test.ts
+++ b/tests/e2e/players-neighbors.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@playwright/test';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:5173';
+const MOCK_API_URL = process.env.E2E_MOCK_API_URL ?? 'http://localhost:5800';
+const PLAYERS_URL = `${BASE_URL}/?view=players`;
+
+test('similar accounts entry point anchors the SID window on a player', async ({ page }) => {
+	await page.goto(PLAYERS_URL);
+
+	const table = page.locator('table');
+	await expect(table.getByText('MockPlayer1', { exact: true })).toBeVisible({ timeout: 10000 });
+
+	// Enter neighbor mode from the row action
+	await page
+		.locator('tr', { has: page.getByText('MockPlayer1', { exact: true }) })
+		.locator('[data-testid="find-neighbors"]')
+		.click();
+
+	await expect(page.locator('[data-testid="sid-mode-banner"]')).toBeVisible();
+	await expect(page).toHaveURL(/sort=sid/);
+	await expect(page).toHaveURL(/anchor=MockPlayer1/);
+
+	// The anchored player is highlighted inside the window
+	await expect(page.locator('tr.highlighted-row')).toContainText('MockPlayer1');
+
+	// Page numbers are replaced by absolute window navigation
+	await expect(page.locator('[data-testid="sid-window-nav"]')).toBeVisible();
+});
+
+test('window navigation moves through neighbors by absolute offset', async ({ page }) => {
+	await page.goto(`${PLAYERS_URL}&sort=sid&anchor=MockPlayer1`);
+
+	await expect(page.locator('[data-testid="sid-mode-banner"]')).toBeVisible({ timeout: 10000 });
+	const firstRow = page.locator('tbody tr').first();
+	const firstRowNumber = await firstRow.locator('td').first().innerText();
+
+	await page.locator('[data-testid="sid-window-next"]').click();
+
+	await expect(async () => {
+		const shiftedRowNumber = await page
+			.locator('tbody tr')
+			.first()
+			.locator('td')
+			.first()
+			.innerText();
+		expect(Number(shiftedRowNumber)).toBe(Number(firstRowNumber) + 20);
+	}).toPass({ timeout: 10000 });
+
+	// Still browsing the same player's neighborhood
+	await expect(page.locator('[data-testid="sid-mode-banner"]')).toBeVisible();
+});
+
+test('unknown anchor reports the fallback instead of pretending to show neighbors', async ({
+	page
+}) => {
+	await page.goto(`${PLAYERS_URL}&sort=sid&anchor=NoSuchPlayerAtAll`);
+
+	await expect(page.locator('[data-testid="sid-anchor-missing"]')).toBeVisible({ timeout: 10000 });
+	// Neighbor mode was left, so the window navigation is gone
+	await expect(page.locator('[data-testid="sid-window-nav"]')).toHaveCount(0);
+});
+
+test('player list API honours the sid sort and rejects unknown sort values', async ({
+	request
+}) => {
+	const sidResponse = await request.get(
+		`${MOCK_API_URL}/api/player_list?db=invasion&sort=sid&start=0&size=20`
+	);
+	expect(sidResponse.ok()).toBeTruthy();
+	const sidHtml = await sidResponse.text();
+	// sid ordering is not the default ordering: it starts on a different player
+	expect(sidHtml).toMatch(/<td>1<\/td>\s*<td>MockPlayer60<\/td>/);
+
+	const defaultResponse = await request.get(
+		`${MOCK_API_URL}/api/player_list?db=invasion&start=0&size=20`
+	);
+	const defaultHtml = await defaultResponse.text();
+	expect(defaultHtml).toMatch(/<td>1<\/td>\s*<td>MockPlayer1<\/td>/);
+
+	const brokenResponse = await request.get(
+		`${MOCK_API_URL}/api/player_list?db=invasion&sort=garbage`
+	);
+	const brokenHtml = await brokenResponse.text();
+	expect(brokenHtml).not.toContain('MockPlayer');
+});

--- a/tests/unit/components/PlayerView.svelte.test.ts
+++ b/tests/unit/components/PlayerView.svelte.test.ts
@@ -700,4 +700,58 @@ describe('PlayerView Component', () => {
 			expect(desktopContainer).toBeInTheDocument();
 		});
 	});
+
+	describe('mobile highlight', () => {
+		const mobileProps = {
+			loading: false,
+			error: null,
+			searchQuery: '',
+			paginatedPlayers: mockPlayers,
+			mobilePaginatedPlayers: mockPlayers,
+			mobileHasMore: false,
+			mobileLoadingMore: false,
+			playerColumns: mockPlayerColumns,
+			visibleColumns: mockVisibleColumns,
+			currentPage: 1,
+			pageSize: 20,
+			sortColumn: null,
+			mobileExpandedCards: {},
+			layoutMode: 'fullPage' as const,
+			hasNext: false,
+			hasPrevious: false,
+			onSort: mockOnSort as any,
+			onPageChange: mockOnPageChange as any,
+			onPageSizeChange: mockOnPageSizeChange as any,
+			onLoadMore: mockOnLoadMore as any,
+			onToggleMobileCard: mockOnToggleMobileCard as any
+		};
+
+		it('should highlight the mobile card of the highlighted player', () => {
+			const { container } = render(PlayerView, {
+				props: { ...mobileProps, highlightedUsername: 'Player2' }
+			});
+
+			const highlighted = container.querySelectorAll('.highlighted-card');
+			expect(highlighted).toHaveLength(1);
+			expect(container.querySelector('#player-mobile-card-player2')).toHaveClass(
+				'highlighted-card'
+			);
+		});
+
+		it('should match the highlighted username case-insensitively', () => {
+			const { container } = render(PlayerView, {
+				props: { ...mobileProps, highlightedUsername: 'pLaYeR1' }
+			});
+
+			expect(container.querySelector('#player-mobile-card-player1')).toHaveClass(
+				'highlighted-card'
+			);
+		});
+
+		it('should highlight nothing without a highlighted username', () => {
+			const { container } = render(PlayerView, { props: mobileProps });
+
+			expect(container.querySelectorAll('.highlighted-card')).toHaveLength(0);
+		});
+	});
 });

--- a/tests/unit/models/player-sort-fields.test.ts
+++ b/tests/unit/models/player-sort-fields.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from 'vitest';
+import {
+	PLAYER_SORT_FIELDS,
+	SID_SORT_FIELD,
+	isPlayerSortField,
+	toPlayerSortField
+} from '$lib/models/player.model';
+
+describe('player sort fields', () => {
+	test('should include the undocumented sid field', () => {
+		expect(PLAYER_SORT_FIELDS).toContain('sid');
+		expect(SID_SORT_FIELD).toBe('sid');
+	});
+
+	describe('isPlayerSortField', () => {
+		test('should accept every known field', () => {
+			for (const field of PLAYER_SORT_FIELDS) {
+				expect(isPlayerSortField(field)).toBe(true);
+			}
+		});
+
+		test('should reject unknown values', () => {
+			// Upstream answers with an empty table for these, so they must never be sent
+			expect(isPlayerSortField('garbage')).toBe(false);
+			expect(isPlayerSortField('SID')).toBe(false);
+			expect(isPlayerSortField('')).toBe(false);
+			expect(isPlayerSortField(undefined)).toBe(false);
+			expect(isPlayerSortField(null)).toBe(false);
+			expect(isPlayerSortField(42)).toBe(false);
+		});
+	});
+
+	describe('toPlayerSortField', () => {
+		test('should convert camelCase column keys to snake_case fields', () => {
+			expect(toPlayerSortField('rankProgression')).toBe('rank_progression');
+			expect(toPlayerSortField('longestKillStreak')).toBe('longest_kill_streak');
+			expect(toPlayerSortField('kills')).toBe('kills');
+		});
+
+		test('should pass sid through unchanged', () => {
+			expect(toPlayerSortField('sid')).toBe('sid');
+		});
+
+		test('should return undefined for keys the player API cannot sort by', () => {
+			// Server table columns can reach here through the shared `sort` URL parameter
+			expect(toPlayerSortField('totalPlayers')).toBeUndefined();
+			expect(toPlayerSortField('ipAddress')).toBeUndefined();
+			expect(toPlayerSortField('name')).toBeUndefined();
+			expect(toPlayerSortField('rankName')).toBeUndefined();
+		});
+	});
+});

--- a/tests/unit/services/players.test.ts
+++ b/tests/unit/services/players.test.ts
@@ -402,4 +402,41 @@ describe('PlayerService', () => {
 			expect(url).toContain('/api/player_list?');
 		});
 	});
+
+	describe('sid sort field', () => {
+		test('should forward the undocumented sid sort field', async () => {
+			mockRequest.mockResolvedValue('<html><body><table>...</table></body></html>');
+			mockParsePlayerListWithPagination.mockReturnValue({
+				players: mockPlayers,
+				hasNext: true,
+				hasPrevious: false
+			});
+
+			await PlayerService.listWithPagination({
+				db: PlayerDatabase.INVASION,
+				search: 'SGT.BONETRAIN',
+				sort: 'sid',
+				size: 20
+			});
+
+			const url = mockRequest.mock.calls[0][0] as string;
+			expect(url).toContain('sort=sid');
+			expect(url).toContain('search=SGT.BONETRAIN');
+		});
+
+		test('should still send start=0 when the caller omits it', async () => {
+			// Harmless for anchored requests: upstream ignores `start` while `search` is present
+			mockRequest.mockResolvedValue('<html><body><table>...</table></body></html>');
+			mockParsePlayerListWithPagination.mockReturnValue({
+				players: mockPlayers,
+				hasNext: true,
+				hasPrevious: false
+			});
+
+			await PlayerService.listWithPagination({ sort: 'sid', search: 'Someone' });
+
+			const url = mockRequest.mock.calls[0][0] as string;
+			expect(url).toContain('start=0');
+		});
+	});
 });

--- a/tests/unit/stores/use-player-state-sid.test.ts
+++ b/tests/unit/stores/use-player-state-sid.test.ts
@@ -151,16 +151,20 @@ describe('createPlayerState - SID neighbor mode', () => {
 		});
 
 		it('should clamp backward shifts to the top of the list', async () => {
-			mockResponse(createWindow(1, ['A']));
+			// A response for start=70 starts at row 71, so the next shift rebases from there
+			mockResponse(createWindow(71, ['A', 'B']));
 
 			playerState.shiftSidWindow(-1);
 			await playerState.loadPlayers();
 
-			expect(PlayerService.listWithPagination).toHaveBeenCalledWith(
+			expect(PlayerService.listWithPagination).toHaveBeenLastCalledWith(
 				expect.objectContaining({ start: 70 })
 			);
 
-			playerState.shiftSidWindow(-1);
+			// A page larger than the rows above the window must clamp instead of going negative
+			playerState.handlePlayerPageSizeChange(100);
+			mockResponse(createWindow(1, ['A']));
+
 			playerState.shiftSidWindow(-1);
 			await playerState.loadPlayers();
 
@@ -237,6 +241,66 @@ describe('createPlayerState - SID neighbor mode', () => {
 				expect.objectContaining({ search: undefined, sort: 'sid', start: 110 })
 			);
 			expect(playerState.players).toHaveLength(3);
+		});
+	});
+
+	describe('stale responses', () => {
+		it('should drop a response that a newer query superseded', async () => {
+			let resolveStale: (value: {
+				players: IPlayerItem[];
+				hasNext: boolean;
+				hasPrevious: boolean;
+			}) => void = () => {};
+			vi.mocked(PlayerService.listWithPagination).mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveStale = resolve;
+					})
+			);
+
+			const stalePending = playerState.loadPlayers();
+
+			mockResponse(createWindow(1, ['Fresh']));
+			await playerState.loadPlayers();
+
+			resolveStale({ players: createWindow(500, ['Stale']), hasNext: true, hasPrevious: true });
+			await stalePending;
+
+			expect(playerState.players.map((player) => player.username)).toEqual(['Fresh']);
+			expect(playerState.loading).toBe(false);
+		});
+
+		it('should not let a stale anchored response leave neighbor mode', async () => {
+			let resolveStale: (value: {
+				players: IPlayerItem[];
+				hasNext: boolean;
+				hasPrevious: boolean;
+			}) => void = () => {};
+			vi.mocked(PlayerService.listWithPagination).mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveStale = resolve;
+					})
+			);
+
+			playerState.enterSidNeighborMode('Gone');
+			const stalePending = playerState.loadPlayers();
+
+			// User picks another anchor before the first request comes back
+			mockResponse(createWindow(41, ['Target']));
+			playerState.enterSidNeighborMode('Target');
+			await playerState.loadPlayers();
+
+			resolveStale({
+				players: createWindow(1, ['Someone']),
+				hasNext: true,
+				hasPrevious: false
+			});
+			await stalePending;
+
+			expect(playerState.sidAnchor).toBe('Target');
+			expect(playerState.sidAnchorMissing).toBe(false);
+			expect(playerState.players.map((player) => player.username)).toEqual(['Target']);
 		});
 	});
 

--- a/tests/unit/stores/use-player-state-sid.test.ts
+++ b/tests/unit/stores/use-player-state-sid.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPlayerState } from '$lib/stores/use-player-state.svelte';
+import { PlayerService } from '$lib/services/players';
+import type { IPlayerItem } from '$lib/models/player.model';
+import { PlayerDatabase } from '$lib/models/player.model';
+
+// Mock PlayerService
+vi.mock('$lib/services/players', () => ({
+	PlayerService: {
+		listWithPagination: vi.fn()
+	}
+}));
+
+/**
+ * "Similar accounts" mode relies on two upstream behaviours:
+ * - `sort=sid` orders by Steam ID but the response never contains the value
+ * - while `search` is present `start` is ignored and the window starts 10 rows
+ *   before the matched player; an unknown name silently returns the first page
+ */
+describe('createPlayerState - SID neighbor mode', () => {
+	let playerState: ReturnType<typeof createPlayerState>;
+
+	const createWindow = (firstRowNumber: number, usernames: string[]): IPlayerItem[] =>
+		usernames.map((username, index) => ({
+			id: `invasion:${username}`,
+			username,
+			db: PlayerDatabase.INVASION,
+			rowNumber: firstRowNumber + index,
+			rankProgression: 100,
+			kills: 10,
+			deaths: 5,
+			kd: 2,
+			score: 5,
+			timePlayed: '1h',
+			teamkills: 0,
+			longestKillStreak: 1,
+			targetsDestroyed: 0,
+			vehiclesDestroyed: 0,
+			soldiersHealed: 0,
+			distanceMoved: '1km',
+			shotsFired: 100,
+			throwablesThrown: 0,
+			rankName: 'Private',
+			rankIcon: null
+		}));
+
+	const mockResponse = (players: IPlayerItem[], hasNext = true, hasPrevious = true) => {
+		vi.mocked(PlayerService.listWithPagination).mockResolvedValue({
+			players,
+			hasNext,
+			hasPrevious
+		});
+	};
+
+	beforeEach(() => {
+		playerState = createPlayerState();
+		vi.clearAllMocks();
+	});
+
+	describe('enterSidNeighborMode', () => {
+		it('should anchor the request on the username without sending start', async () => {
+			mockResponse(createWindow(91, ['Other', 'Target', 'Another']));
+
+			playerState.enterSidNeighborMode('Target');
+			await playerState.loadPlayers({ searchQuery: 'ignored' });
+
+			expect(PlayerService.listWithPagination).toHaveBeenCalledWith(
+				expect.objectContaining({
+					search: 'Target',
+					sort: 'sid',
+					start: undefined
+				})
+			);
+			expect(playerState.sidNeighborMode).toBe(true);
+			expect(playerState.sidAnchor).toBe('Target');
+			expect(playerState.playerSortColumn).toBe('sid');
+		});
+
+		it('should claim no sort direction because upstream has none for sid', () => {
+			playerState.enterSidNeighborMode('Target');
+			expect(playerState.playerSortDirection).toBeNull();
+		});
+
+		it('should match the anchor case-insensitively', async () => {
+			mockResponse(createWindow(1, ['target']));
+
+			playerState.enterSidNeighborMode('TARGET');
+			await playerState.loadPlayers();
+
+			expect(playerState.sidAnchorMissing).toBe(false);
+			expect(playerState.sidNeighborMode).toBe(true);
+		});
+
+		it('should leave neighbor mode and flag it when the anchor is missing', async () => {
+			// Upstream fell back to rank 1 instead of erroring
+			mockResponse(createWindow(1, ['Someone', 'SomeoneElse']));
+
+			playerState.enterSidNeighborMode('UnknownPlayer');
+			await playerState.loadPlayers();
+
+			expect(playerState.sidAnchorMissing).toBe(true);
+			expect(playerState.sidNeighborMode).toBe(false);
+			expect(playerState.sidAnchor).toBeNull();
+			// Rows on screen really are SID-ordered, so the ordering badge stays truthful
+			expect(playerState.playerSortColumn).toBe('sid');
+		});
+
+		it('should clear the missing flag when dismissed', async () => {
+			mockResponse(createWindow(1, ['Someone']));
+			playerState.enterSidNeighborMode('UnknownPlayer');
+			await playerState.loadPlayers();
+
+			playerState.dismissSidAnchorMissing();
+
+			expect(playerState.sidAnchorMissing).toBe(false);
+		});
+	});
+
+	describe('shiftSidWindow', () => {
+		beforeEach(async () => {
+			mockResponse(createWindow(91, ['A', 'Target', 'C']));
+			playerState.enterSidNeighborMode('Target');
+			await playerState.loadPlayers();
+			vi.mocked(PlayerService.listWithPagination).mockClear();
+		});
+
+		it('should request an absolute offset without search so start is honoured', async () => {
+			mockResponse(createWindow(110, ['D', 'E']));
+
+			playerState.shiftSidWindow(1);
+			await playerState.loadPlayers({ searchQuery: 'ignored' });
+
+			expect(PlayerService.listWithPagination).toHaveBeenCalledWith(
+				expect.objectContaining({
+					search: undefined,
+					sort: 'sid',
+					// window top (row 91 -> start 90) plus one page of 20
+					start: 110
+				})
+			);
+		});
+
+		it('should keep the anchor so the player stays highlighted while browsing', async () => {
+			mockResponse(createWindow(110, ['D', 'E']));
+
+			playerState.shiftSidWindow(1);
+			await playerState.loadPlayers();
+
+			expect(playerState.sidAnchor).toBe('Target');
+			expect(playerState.sidAnchorMissing).toBe(false);
+		});
+
+		it('should clamp backward shifts to the top of the list', async () => {
+			mockResponse(createWindow(1, ['A']));
+
+			playerState.shiftSidWindow(-1);
+			await playerState.loadPlayers();
+
+			expect(PlayerService.listWithPagination).toHaveBeenCalledWith(
+				expect.objectContaining({ start: 70 })
+			);
+
+			playerState.shiftSidWindow(-1);
+			playerState.shiftSidWindow(-1);
+			await playerState.loadPlayers();
+
+			expect(PlayerService.listWithPagination).toHaveBeenLastCalledWith(
+				expect.objectContaining({ start: 0 })
+			);
+		});
+	});
+
+	describe('exitSidNeighborMode', () => {
+		it('should drop the anchor and the sid ordering', async () => {
+			mockResponse(createWindow(91, ['Target']));
+			playerState.enterSidNeighborMode('Target');
+			await playerState.loadPlayers();
+
+			playerState.exitSidNeighborMode();
+
+			expect(playerState.sidNeighborMode).toBe(false);
+			expect(playerState.playerSortColumn).toBeNull();
+			expect(playerState.playerSortDirection).toBeNull();
+		});
+
+		it('should keep a non-sid sort untouched', () => {
+			playerState.handleSort('kills');
+			playerState.exitSidNeighborMode();
+
+			expect(playerState.playerSortColumn).toBe('kills');
+		});
+	});
+
+	describe('interaction with other state', () => {
+		it('should leave neighbor mode when a visible column is sorted', async () => {
+			mockResponse(createWindow(91, ['Target']));
+			playerState.enterSidNeighborMode('Target');
+			await playerState.loadPlayers();
+
+			playerState.handleSort('kills');
+			await playerState.loadPlayers();
+
+			expect(playerState.sidNeighborMode).toBe(false);
+			expect(PlayerService.listWithPagination).toHaveBeenLastCalledWith(
+				expect.objectContaining({ sort: 'kills', search: undefined, start: 0 })
+			);
+		});
+
+		it('should re-anchor after a database change instead of reusing the offset', async () => {
+			mockResponse(createWindow(91, ['A', 'Target']));
+			playerState.enterSidNeighborMode('Target');
+			await playerState.loadPlayers();
+			playerState.shiftSidWindow(1);
+
+			playerState.handlePlayerDbChange(PlayerDatabase.PACIFIC);
+			mockResponse(createWindow(41, ['Target']));
+			await playerState.loadPlayers();
+
+			expect(PlayerService.listWithPagination).toHaveBeenLastCalledWith(
+				expect.objectContaining({
+					db: PlayerDatabase.PACIFIC,
+					search: 'Target',
+					start: undefined
+				})
+			);
+		});
+
+		it('should append the next absolute slice on mobile load more', async () => {
+			mockResponse(createWindow(91, ['A', 'Target']));
+			playerState.enterSidNeighborMode('Target');
+			await playerState.loadPlayers();
+
+			mockResponse(createWindow(111, ['B']));
+			await playerState.handleLoadMore();
+
+			expect(PlayerService.listWithPagination).toHaveBeenLastCalledWith(
+				expect.objectContaining({ search: undefined, sort: 'sid', start: 110 })
+			);
+			expect(playerState.players).toHaveLength(3);
+		});
+	});
+
+	describe('setSortState validation', () => {
+		it('should keep sid coming from a shared URL', () => {
+			playerState.setSortState('sid', null);
+			expect(playerState.playerSortColumn).toBe('sid');
+		});
+
+		it('should keep valid player columns', () => {
+			playerState.setSortState('rankProgression', 'desc');
+			expect(playerState.playerSortColumn).toBe('rankProgression');
+		});
+
+		it('should drop values the player API would answer with an empty table', () => {
+			playerState.setSortState('totalPlayers', 'desc');
+
+			expect(playerState.playerSortColumn).toBeNull();
+			expect(playerState.playerSortDirection).toBeNull();
+		});
+
+		it('should not send a dropped sort value to the API', async () => {
+			mockResponse(createWindow(1, ['A']));
+			playerState.setSortState('ipAddress', 'asc');
+
+			await playerState.loadPlayers();
+
+			expect(PlayerService.listWithPagination).toHaveBeenCalledWith(
+				expect.objectContaining({ sort: undefined })
+			);
+		});
+	});
+});

--- a/tests/unit/stores/use-player-state-sid.test.ts
+++ b/tests/unit/stores/use-player-state-sid.test.ts
@@ -270,6 +270,47 @@ describe('createPlayerState - SID neighbor mode', () => {
 			expect(playerState.loading).toBe(false);
 		});
 
+		it('should drop a response whose sort was replaced through URL sync', async () => {
+			let resolveStale: (value: {
+				players: IPlayerItem[];
+				hasNext: boolean;
+				hasPrevious: boolean;
+			}) => void = () => {};
+			vi.mocked(PlayerService.listWithPagination).mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveStale = resolve;
+					})
+			);
+
+			playerState.setSortState('kills', 'desc');
+			const stalePending = playerState.loadPlayers();
+
+			// Browser history moved to another sort while the request was in flight
+			playerState.setSortState('deaths', 'desc');
+
+			resolveStale({
+				players: createWindow(1, ['SortedByKills']),
+				hasNext: true,
+				hasPrevious: false
+			});
+			await stalePending;
+
+			expect(playerState.players).toEqual([]);
+			expect(playerState.loading).toBe(false);
+		});
+
+		it('should keep an in-flight response when URL sync repeats the same sort', async () => {
+			mockResponse(createWindow(1, ['Fresh']));
+
+			playerState.setSortState('kills', 'desc');
+			const pending = playerState.loadPlayers();
+			playerState.setSortState('kills', 'desc');
+			await pending;
+
+			expect(playerState.players.map((player) => player.username)).toEqual(['Fresh']);
+		});
+
 		it('should not let a stale anchored response leave neighbor mode', async () => {
 			let resolveStale: (value: {
 				players: IPlayerItem[];

--- a/tests/unit/stores/use-url-sync.test.ts
+++ b/tests/unit/stores/use-url-sync.test.ts
@@ -286,6 +286,14 @@ describe('createUrlSync', () => {
 			expect(mockPlayerState.setSortState).toHaveBeenCalledWith('name', null);
 		});
 
+		it('should clear sort state when the URL has no sort parameter', () => {
+			// Browser Back to a URL without `sort` must not keep the previous sort
+			urlSync.handleUrlStateChange({ search: 'test' });
+
+			expect(mockServerState.setSortState).toHaveBeenCalledWith(null, null);
+			expect(mockPlayerState.setSortState).toHaveBeenCalledWith(null, null);
+		});
+
 		it('should call onViewChange when view changes', () => {
 			const urlState: UrlState = { view: 'players' };
 			urlSync.handleUrlStateChange(urlState);

--- a/tests/unit/utils/url-state.test.ts
+++ b/tests/unit/utils/url-state.test.ts
@@ -400,4 +400,65 @@ describe('URL State Management', () => {
 			);
 		});
 	});
+
+	describe('similar accounts anchor', () => {
+		test('should parse the anchor parameter', () => {
+			mockWindow.location.search = '?sort=sid&anchor=SGT.BONETRAIN';
+			const state = getUrlState();
+
+			expect(state.sidAnchor).toBe('SGT.BONETRAIN');
+			expect(state.sortColumn).toBe('sid');
+		});
+
+		test('should ignore an empty anchor parameter', () => {
+			mockWindow.location.search = '?anchor=';
+			const state = getUrlState();
+
+			expect(state.sidAnchor).toBeUndefined();
+		});
+
+		test('should write the anchor into the URL', () => {
+			updateUrlState({ sidAnchor: 'SGT.BONETRAIN' });
+
+			expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+				mockWindow.history.state,
+				'',
+				`/test?${URL_PARAMS.SID_ANCHOR}=SGT.BONETRAIN`
+			);
+		});
+
+		test('should remove the anchor when cleared', () => {
+			mockWindow.location.search = '?anchor=SGT.BONETRAIN';
+			updateUrlState({ sidAnchor: undefined });
+
+			expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+				mockWindow.history.state,
+				'',
+				'/test'
+			);
+		});
+
+		test('should round-trip a shared neighbor link', () => {
+			mockWindow.location.search = '?view=players&db=pacific&sort=sid&anchor=Someone';
+			const state = getUrlState();
+
+			expect(state).toEqual({
+				view: 'players',
+				playerDb: PlayerDatabase.PACIFIC,
+				sortColumn: 'sid',
+				sidAnchor: 'Someone'
+			});
+		});
+
+		test('should drop the anchor together with the rest of the state', () => {
+			mockWindow.location.search = '?search=a&anchor=Someone&sort=sid';
+			clearUrlState();
+
+			expect(mockWindow.history.replaceState).toHaveBeenCalledWith(
+				mockWindow.history.state,
+				'',
+				'/test'
+			);
+		});
+	});
 });


### PR DESCRIPTION
Add a "similar accounts" row action that sorts the player list by the undocumented `sid` field. The API orders by Steam ID but never returns it, so the window is positioned by anchoring on the selected username; user-driven shifts then navigate by absolute offsets.

The anchored window is shareable via a new `anchor` URL parameter, with history back/forward synced. An unknown anchor makes upstream fall back to the first page, which is surfaced as a warning instead of pretending to show neighbors.

Also validate sort fields before sending: an unknown value makes upstream answer with an empty table, so camelCase column keys from the shared sort URL parameter are converted and rejected when the player API cannot sort by them. Fix the URL sync subscriber that previously short-circuited on quick filters, skipping the remaining state changes.

Includes i18n messages, analytics events, and unit/e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Similar accounts” navigation from player rows.
  * Added anchored neighbor views with highlighting, previous/next navigation, mobile support, and missing-account warnings.
  * Added URL support for preserving similar-account navigation state.
  * Enabled player row actions by default.
  * Added English and Simplified Chinese translations and accessibility labels.

* **Bug Fixes**
  * Improved validation and synchronization of player sorting, filters, views, and navigation state.

* **Tests**
  * Added coverage for neighbor navigation, sorting, URL state, mobile behavior, and invalid anchors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->